### PR TITLE
Optimize xFilter function for better performance

### DIFF
--- a/Code Templates/Filter XMLLists/xFilter.js
+++ b/Code Templates/Filter XMLLists/xFilter.js
@@ -1,38 +1,54 @@
 /**
-	Improved XMLList filter over built-in e4x filters.
+    Improved XMLList filter over built-in e4x filters.
 
-        @copyright 2020 Tony Germano
-        @license MPL-2.0
+    @copyright 2020,2025 Tony Germano
+    @version 1.1 - performance optimizations for large lists
+    @license MPL-2.0
 
-	@param {XMLList} xmlList - The XMLList to be filtered
-	@param {Function} callback - Function is a predicate, to test each node of the XMLList. Return
-		true to keep the element, false otherwise. It accepts 3 arguments - the node, the index of the node,
-		and xmlList as passed into xFilter
-	@param {Number} minLimit - (Optional) throw RangeError if at least this many nodes do not pass the
-		filter
-	@param {Number} maxReturned - (Optional) only return up to this many results
-	@param {Boolean} enforceMax - (Optional) throw RangeError if more than maxReturned results will
-		be returned
-	@return {XMLList} new XMLList containing filtered results
+    @param {XMLList} xmlList - The XMLList to be filtered
+    @param {Function} callback - Function is a predicate, to test each node of the XMLList. Return
+        true to keep the element, false otherwise. It accepts 3 arguments - the node, the index of the node,
+        and xmlList as passed into xFilter
+    @param {Number} minLimit - (Optional) throw RangeError if at least this many nodes do not pass the
+        filter
+    @param {Number} maxReturned - (Optional) only return up to this many results
+    @param {Boolean} enforceMax - (Optional) throw RangeError if more than maxReturned results will
+        be returned
+    @return {XMLList} new XMLList containing filtered results
 */
 function xFilter(xmlList, callback, minLimit, maxReturned, enforceMax) {
-    var ret = new XMLList();
-    for (var i = 0; i < xmlList.length(); i++) {
-        var node = xmlList[i];
+    if (minLimit === undefined) minLimit = 0
+    if (maxReturned === undefined) maxReturned = Infinity
+    if (enforceMax === undefined) enforceMax = false
+    var ret = new XMLList()
+    var i = 0
+    var match_count = 0
+    var first_match
+    for each (var node in xmlList) {
         if (callback(node, i, xmlList)) {
-            ret += node;
+            if (first_match === undefined) {
+                first_match = node
+                ret[match_count++] = new XML()
+            }
+            else {
+                ret[match_count++] = node
+            }
             if (enforceMax) {
-                if (ret.length() > maxReturned) {
-                    throw new RangeError('The number of filtered results is more than ' + maxReturned);
+                if (match_count > maxReturned) {
+                    throw new RangeError('The number of filtered results is more than ' + maxReturned)
                 }
             }
-            else if (ret.length() == maxReturned) {
-                break;
+            else if (match_count == maxReturned) {
+                break
             }
         }
+        i++
     }
-    if (ret.length() < minLimit) {
-        throw new RangeError('The number of filtered results is less than ' + minLimit);
+    if (match_count < minLimit) {
+        throw new RangeError('The number of filtered results is less than ' + minLimit)
     }
-    return ret;
+    if (first_match) {
+        ret[0] = first_match
+    }
+    return ret
 }


### PR DESCRIPTION
Open Integration Engine Discord user `@Anibal` reported slowness issues when working with very large lists, e.g., filtering HL7 messages with several thousand OBX segments.

One thing that was already known to me is that where `list` is an `XMLList` and `node` is an `XML` object, performing `list += node` will assign a new `XMLList` to `list`, which is a shallow copy of the original `list` with `node` appended to the end. Assigning `list[index] = node` where `index` is greater than or equal to the length of `list` will append to the list without copying it first.

A caveat to this is that when all elements of an `XMLList` share the same `parent`, assignments in this manner will not only update `list`, but will also attempt to update the parent's child list. To get around this, the would-be first element of the returned list is remembered, and an empty XML object with no parent is inserted into the list in its place. The remainder of the list is built as normal, and at the end, the first element in the list is replaced with the reserved object.

Through benchmarking shared in the discord chat, two additional optimizations were found. First, it is much faster to iterate over an XMLList using a `for each..in` loop than it is to use a normal `for` loop and access the list by index. Second, `list.length()` is much slower than expected, so the function scoped `match_count` is used to track the current length instead.